### PR TITLE
Pickup latest ubi header struct

### DIFF
--- a/src/pld/gemini.c
+++ b/src/pld/gemini.c
@@ -462,7 +462,7 @@ static int gemini_program_bitstream(struct target *target, gemini_bit_file_t *bi
 		LOG_ERROR("[RS] Failed to program bitstream to the device");
 	}
 	else
-		LOG_INFO("[RS] Device is programmed successfully");
+		LOG_INFO("[RS] Gemini FPGA fabric is configured successfully");
 
 	return retval;
 }

--- a/src/pld/gemini.c
+++ b/src/pld/gemini.c
@@ -280,7 +280,7 @@ static int gemini_poll_command_complete_and_status(struct target * target, uint3
 
 	while (1)
 	{
-		LOG_INFO("[RS] Poll command status #%d...", ++num_polls);
+		LOG_DEBUG("[RS] Poll command status #%d...", ++num_polls);
 
 		retval = gemini_get_command_status(target, status);
 		if (retval != ERROR_OK)
@@ -356,7 +356,7 @@ static int gemini_load_fsbl(struct target *target, gemini_bit_file_t *bit_file)
 		return ERROR_FAIL;
 	}
 
-	LOG_INFO("[RS] Wrote %d bytes to SRAM at 0x%08x", fsbl_size, GEMINI_SRAM_ADDRESS);
+	LOG_DEBUG("[RS] Wrote %d bytes to SRAM at 0x%08x", fsbl_size, GEMINI_SRAM_ADDRESS);
 
 	if (gemini_write_reg32(target, GEMINI_SPARE_REG, 16, 0, GEMINI_PRG_TSK_CMD_BBF_FDI) != ERROR_OK)
 	{
@@ -364,7 +364,7 @@ static int gemini_load_fsbl(struct target *target, gemini_bit_file_t *bit_file)
 		return ERROR_FAIL;
 	}
 
-	LOG_INFO("[RS] Wrote command 0x%x to spare_reg at 0x%08x", GEMINI_PRG_TSK_CMD_BBF_FDI, GEMINI_SPARE_REG);
+	LOG_DEBUG("[RS] Wrote command 0x%x to spare_reg at 0x%08x", GEMINI_PRG_TSK_CMD_BBF_FDI, GEMINI_SPARE_REG);
 
 	retval = gemini_poll_command_complete_and_status(target, &status);
 	if (retval == ERROR_OK)
@@ -431,7 +431,7 @@ static int gemini_program_bitstream(struct target *target, gemini_bit_file_t *bi
 	uint32_t filesize = (uint32_t)bit_file->filesize;
 	uint32_t size = 1;
 
-	LOG_INFO("[RS] Program bitstream to Gemini device...");
+	LOG_INFO("[RS] Configuring Gemini FPGA fabric...");
 
 	if ((filesize % 4) == 0)
 		size = 4;
@@ -444,7 +444,7 @@ static int gemini_program_bitstream(struct target *target, gemini_bit_file_t *bi
 		return ERROR_FAIL;
 	}
 
-	LOG_INFO("[RS] Wrote %d byte(s) to DDR memory at 0x%08x", filesize, GEMINI_LOAD_ADDRESS);
+	LOG_DEBUG("[RS] Wrote %d bytes to DDR memory at 0x%08x", filesize, GEMINI_LOAD_ADDRESS);
 
 	if (gemini_write_reg32(target, GEMINI_SPARE_REG, 16, 0, GEMINI_PRG_TSK_CMD_CFG_BITSTREAM_FPGA) != ERROR_OK)
 	{
@@ -452,7 +452,7 @@ static int gemini_program_bitstream(struct target *target, gemini_bit_file_t *bi
 		return ERROR_FAIL;
 	}
 
-	LOG_INFO("[RS] Wrote command 0x%x to spare_reg at 0x%08x", GEMINI_PRG_TSK_CMD_CFG_BITSTREAM_FPGA, GEMINI_SPARE_REG);
+	LOG_DEBUG("[RS] Wrote command 0x%x to spare_reg at 0x%08x", GEMINI_PRG_TSK_CMD_CFG_BITSTREAM_FPGA, GEMINI_SPARE_REG);
 
 	retval = gemini_poll_command_complete_and_status(target, &status);
 	if (retval != ERROR_OK)

--- a/src/pld/gemini_bit.c
+++ b/src/pld/gemini_bit.c
@@ -68,7 +68,7 @@ int gemini_read_bit_file(gemini_bit_file_t *bit_file, const char *filename)
 	}
 
 	// sanity check to see if fsbl_size (if it exists) is within the file content boundary
-	if (bit_file->ubi_header->fsbl_size != 0 && bit_file->ubi_header->fsbl_size > bit_file->filesize)
+	if (bit_file->ubi_header->fsbl_size != 0 && (long)bit_file->ubi_header->fsbl_size > bit_file->filesize)
 	{
 		LOG_ERROR("[RS] Corrupted bitstream content");
 		free(bit_file->ubi_header);

--- a/src/pld/gemini_bit.c
+++ b/src/pld/gemini_bit.c
@@ -11,58 +11,11 @@
 #include <sys/stat.h>
 #include <helper/system.h>
 
-#define RS_CRC16_START 0x0000
-
-static uint16_t crc16_table[256] = {
-	0x0000, 0xc0c1, 0xc181, 0x0140, 0xc301, 0x03c0, 0x0280, 0xc241, 0xc601,
-	0x06c0, 0x0780, 0xc741, 0x0500, 0xc5c1, 0xc481, 0x0440, 0xcc01, 0x0cc0,
-	0x0d80, 0xcd41, 0x0f00, 0xcfc1, 0xce81, 0x0e40, 0x0a00, 0xcac1, 0xcb81,
-	0x0b40, 0xc901, 0x09c0, 0x0880, 0xc841, 0xd801, 0x18c0, 0x1980, 0xd941,
-	0x1b00, 0xdbc1, 0xda81, 0x1a40, 0x1e00, 0xdec1, 0xdf81, 0x1f40, 0xdd01,
-	0x1dc0, 0x1c80, 0xdc41, 0x1400, 0xd4c1, 0xd581, 0x1540, 0xd701, 0x17c0,
-	0x1680, 0xd641, 0xd201, 0x12c0, 0x1380, 0xd341, 0x1100, 0xd1c1, 0xd081,
-	0x1040, 0xf001, 0x30c0, 0x3180, 0xf141, 0x3300, 0xf3c1, 0xf281, 0x3240,
-	0x3600, 0xf6c1, 0xf781, 0x3740, 0xf501, 0x35c0, 0x3480, 0xf441, 0x3c00,
-	0xfcc1, 0xfd81, 0x3d40, 0xff01, 0x3fc0, 0x3e80, 0xfe41, 0xfa01, 0x3ac0,
-	0x3b80, 0xfb41, 0x3900, 0xf9c1, 0xf881, 0x3840, 0x2800, 0xe8c1, 0xe981,
-	0x2940, 0xeb01, 0x2bc0, 0x2a80, 0xea41, 0xee01, 0x2ec0, 0x2f80, 0xef41,
-	0x2d00, 0xedc1, 0xec81, 0x2c40, 0xe401, 0x24c0, 0x2580, 0xe541, 0x2700,
-	0xe7c1, 0xe681, 0x2640, 0x2200, 0xe2c1, 0xe381, 0x2340, 0xe101, 0x21c0,
-	0x2080, 0xe041, 0xa001, 0x60c0, 0x6180, 0xa141, 0x6300, 0xa3c1, 0xa281,
-	0x6240, 0x6600, 0xa6c1, 0xa781, 0x6740, 0xa501, 0x65c0, 0x6480, 0xa441,
-	0x6c00, 0xacc1, 0xad81, 0x6d40, 0xaf01, 0x6fc0, 0x6e80, 0xae41, 0xaa01,
-	0x6ac0, 0x6b80, 0xab41, 0x6900, 0xa9c1, 0xa881, 0x6840, 0x7800, 0xb8c1,
-	0xb981, 0x7940, 0xbb01, 0x7bc0, 0x7a80, 0xba41, 0xbe01, 0x7ec0, 0x7f80,
-	0xbf41, 0x7d00, 0xbdc1, 0xbc81, 0x7c40, 0xb401, 0x74c0, 0x7580, 0xb541,
-	0x7700, 0xb7c1, 0xb681, 0x7640, 0x7200, 0xb2c1, 0xb381, 0x7340, 0xb101,
-	0x71c0, 0x7080, 0xb041, 0x5000, 0x90c1, 0x9181, 0x5140, 0x9301, 0x53c0,
-	0x5280, 0x9241, 0x9601, 0x56c0, 0x5780, 0x9741, 0x5500, 0x95c1, 0x9481,
-	0x5440, 0x9c01, 0x5cc0, 0x5d80, 0x9d41, 0x5f00, 0x9fc1, 0x9e81, 0x5e40,
-	0x5a00, 0x9ac1, 0x9b81, 0x5b40, 0x9901, 0x59c0, 0x5880, 0x9841, 0x8801,
-	0x48c0, 0x4980, 0x8941, 0x4b00, 0x8bc1, 0x8a81, 0x4a40, 0x4e00, 0x8ec1,
-	0x8f81, 0x4f40, 0x8d01, 0x4dc0, 0x4c80, 0x8c41, 0x4400, 0x84c1, 0x8581,
-	0x4540, 0x8701, 0x47c0, 0x4680, 0x8641, 0x8201, 0x42c0, 0x4380, 0x8341,
-	0x4100, 0x81c1, 0x8081, 0x4040};
-
-uint16_t rs_crypto_crc16(const unsigned char *input_str, size_t num_bytes)
-{
-	uint16_t crc = RS_CRC16_START;
-
-	if (input_str != NULL) {
-		for (size_t i = 0; i < num_bytes; i++) {
-			crc = (crc >> 8) ^ crc16_table[(crc ^ (uint16_t)*input_str++) & 0x00FF];
-		}
-	}
-
-	return crc;
-}
-
 int gemini_read_bit_file(gemini_bit_file_t *bit_file, const char *filename)
 {
 	FILE *input_file;
 	struct stat input_stat;
 	int read_count;
-	uint32_t header_offset;
 
 	if (!filename || !bit_file)
 		return ERROR_COMMAND_SYNTAX_ERROR;
@@ -89,133 +42,37 @@ int gemini_read_bit_file(gemini_bit_file_t *bit_file, const char *filename)
 	}
 
 	// get file size
-	fseek(input_file, 0L, SEEK_END);
-	bit_file->filesize = ftell(input_file);
-	fseek(input_file, 0L, SEEK_SET);
+	bit_file->filesize = input_stat.st_size;
 
 	// allocate memory for file content
-	bit_file->rawdata = (uint8_t *)malloc(bit_file->filesize);
+	bit_file->ubi_header = (ubi_header_t *)malloc(bit_file->filesize);
 
 	// read entire file content
-	read_count = fread(bit_file->rawdata, sizeof(uint8_t), bit_file->filesize, input_file);
+	read_count = fread(bit_file->ubi_header, sizeof(uint8_t), bit_file->filesize, input_file);
 	if (read_count != bit_file->filesize) {
 		LOG_ERROR("[RS] couldn't read the entire content from file '%s'", filename);
 		fclose(input_file);
-		free(bit_file->rawdata);
+		free(bit_file->ubi_header);
 		return ERROR_PLD_FILE_LOAD_FAILED;
 	}
 
 	// close the file
 	fclose(input_file);
 
-	// parse bit file
-	bit_file->ubi_header = (ubi_header_t *)bit_file->rawdata;
-	bit_file->bop_header_list = (bop_header_t **)malloc(sizeof(bop_header_t *) * bit_file->ubi_header->package_count);
-	header_offset = bit_file->ubi_header->hdr_size;
-
-	// verify ubi header crc
-	uint16_t ubi_header_crc16 = rs_crypto_crc16((const unsigned char *)bit_file->ubi_header, sizeof(ubi_header_t) - 2);
-	if (ubi_header_crc16 != bit_file->ubi_header->crc_16)
+	// sanity check to ensure ubi header version is supported
+	if (bit_file->ubi_header->ubi_hdr_version != UBI_VERSION)
 	{
-		LOG_ERROR("[RS] Invalid UBI Header CRC %x", ubi_header_crc16);
-		free(bit_file->rawdata);
-		free(bit_file->bop_header_list);
-		return ERROR_FAIL;
+		LOG_ERROR("[RS] Unsupported UBI header version %x", bit_file->ubi_header->ubi_hdr_version);
+		free(bit_file->ubi_header);
+		return ERROR_PLD_FILE_LOAD_FAILED;
 	}
 
-	LOG_INFO("[RS] Input file name '%s'", filename);
-	LOG_INFO("[RS] Input file size %ld byte(s)", bit_file->filesize);
-	LOG_INFO("[RS] UBI Header");
-	LOG_INFO("[RS]  Version %d", bit_file->ubi_header->ubi_hdr_version);
-	LOG_INFO("[RS]  Header Size %d", bit_file->ubi_header->hdr_size);
-	LOG_INFO("[RS]  UBI Size %d", bit_file->ubi_header->ubi_size);
-	LOG_INFO("[RS]  Image Type 0x%x", bit_file->ubi_header->image_type);
-	LOG_INFO("[RS]  Package Count %d", bit_file->ubi_header->package_count);
-
-	for (uint8_t i = 0; i < bit_file->ubi_header->package_count; i++)
+	// sanity check to see if fsbl_size (if it exists) is within the file content boundary
+	if (bit_file->ubi_header->fsbl_size != 0 && bit_file->ubi_header->fsbl_size > bit_file->filesize)
 	{
-		if (header_offset >= (uint32_t)bit_file->filesize)
-		{
-			free(bit_file->bop_header_list);
-			free(bit_file->rawdata);
-			return ERROR_PLD_FILE_LOAD_FAILED;
-		}
-
-		bit_file->bop_header_list[i] = (bop_header_t *)(bit_file->rawdata + header_offset);
-		header_offset += bit_file->bop_header_list[i]->offset_to_next_header;
-
-		// verify bop crc
-		uint16_t bop_header_crc16 = rs_crypto_crc16((const unsigned char *)bit_file->bop_header_list[i], sizeof(bop_header_t) - 2);
-		if (bop_header_crc16 != bit_file->bop_header_list[i]->crc_16)
-		{
-			free(bit_file->bop_header_list);
-			free(bit_file->rawdata);
-			LOG_ERROR("[RS] Invalid BOP Header CRC %x", bop_header_crc16);
-			return ERROR_PLD_FILE_LOAD_FAILED;
-		}
-		
-		LOG_INFO("[RS]  BOP Header %d", i);
-		LOG_INFO("[RS]   Id '%.*s'", 4, (char *)&bit_file->bop_header_list[i]->bop_id);
-		LOG_INFO("[RS]   Version %d", bit_file->bop_header_list[i]->bop_hdr_version);
-		LOG_INFO("[RS]   Binary Length %d", bit_file->bop_header_list[i]->binary_len);
-		LOG_INFO("[RS]   Signing Algorithm 0x%x", bit_file->bop_header_list[i]->sig_algo);
-		LOG_INFO("[RS]   Encryption 0x%x", bit_file->bop_header_list[i]->enc_algo);
-	}
-
-	return ERROR_OK;
-}
-
-int gemini_create_helper_bitstream(gemini_bit_file_t *bit_file, uint8_t **bitstream, uint32_t *filesize)
-{
-	bop_header_t *bop_fsbl = NULL;
-	uint32_t padding = 0;
-
-	if (!filesize || !bit_file)
-		return ERROR_COMMAND_SYNTAX_ERROR;
-
-	for (uint8_t i = 0; i < bit_file->ubi_header->package_count; i++)
-	{
-		if (memcmp(&bit_file->bop_header_list[i]->bop_id, "1POB", 4) == 0)
-		{
-			bop_fsbl = bit_file->bop_header_list[i];
-			break;
-		}
-	}
-
-	if (!bop_fsbl)
-	{
-		LOG_ERROR("[RS] FSBL BOP not found");
-		return ERROR_FAIL;
-	}
-
-	// calculate fsbl bop size
-	if (bop_fsbl->offset_to_next_header == 0)
-		*filesize = (bit_file->rawdata + bit_file->filesize) - ((uint8_t *)bop_fsbl);
-	else
-		*filesize = bop_fsbl->offset_to_next_header;
-
-	// add ubi header size
-	*filesize += sizeof(ubi_header_t);
-
-	// add padding if filesize not 32-bit word aligned
-	if ((*filesize & 0x3) != 0) {
-		LOG_WARNING("[RS] FSBL BOP size is not 32-bit word aligned");
-		padding = 4 - (*filesize & 0x3);
-		*filesize += padding;
-	}
-
-	if (bitstream)
-	{
-		*bitstream = (uint8_t *)malloc(*filesize);
-		ubi_header_t *ubi_header = (ubi_header_t *)(*bitstream);
-		bop_header_t *bop_header = (bop_header_t *)(*bitstream + sizeof(ubi_header_t));
-		memcpy(ubi_header, bit_file->ubi_header, sizeof(ubi_header_t));
-		memcpy(bop_header, bop_fsbl, *filesize - sizeof(ubi_header_t) - padding);
-		ubi_header->package_count = 1;
-		ubi_header->ubi_size = *filesize;
-		ubi_header->crc_16 = rs_crypto_crc16((const unsigned char *)ubi_header, sizeof(ubi_header_t) - 2);
-		bop_header->offset_to_next_header = 0;
-		bop_header->crc_16 = rs_crypto_crc16((const unsigned char *)bop_header, sizeof(bop_header_t) - 2);
+		LOG_ERROR("[RS] Corrupted bitstream content");
+		free(bit_file->ubi_header);
+		return ERROR_PLD_FILE_LOAD_FAILED;
 	}
 
 	return ERROR_OK;
@@ -223,6 +80,5 @@ int gemini_create_helper_bitstream(gemini_bit_file_t *bit_file, uint8_t **bitstr
 
 void gemini_free_bit_file(gemini_bit_file_t *bit_file)
 {
-	free(bit_file->bop_header_list);
-	free(bit_file->rawdata);
+	free(bit_file->ubi_header);
 }

--- a/src/pld/gemini_bit.h
+++ b/src/pld/gemini_bit.h
@@ -10,6 +10,8 @@
 
 #include "helper/types.h"
 
+#define UBI_VERSION 0x1
+
 /**
  * @struct   rs_ubi_header
  * @brief    Data structure for Universal Binary Image (UBI) header
@@ -18,68 +20,27 @@
 typedef struct rs_ubi_header {
 	uint16_t ubi_hdr_version;
 	uint16_t hdr_size;
-	/*                     External Image number (64bits)
-	*                   einMsw                         | einLsw
-	* Product ID b[63:48] | Customer Build ID b[47:32] | Image Version b[31:0] */
-	uint32_t ein_msw;  // Product ID b[63:48] | Customer Build ID b[47:32]
-	uint32_t ein_lsw;  // Image Major Ver b[31:0] | Image Minor Ver b[15:0]
+	uint32_t product_id;
+	uint32_t customer_id;
+
+	// image_version [31:0] :
+	// b[31:16] - Image Major Version
+	// b[15: 0] - Image Minor Version
+	uint32_t image_version;
+
 	uint32_t ubi_size;
+	uint32_t fsbl_size; // Size of UBI header + FSBL BOP if it exists
 	uint8_t image_type;
 	uint8_t package_count;
 	uint16_t crc_16;
 } __attribute__((packed)) ubi_header_t;
 
-/**
- * @struct   rs_bop_header
- * @brief    Data structure for Binary Object Protection (BOP) header.
- *
- * BOP IDs List
- * ============
- * BOPK : Key
- * BOP1 : FSBL
- * BOPF : FCB
- * BOPI : ICB
- * BOPP : PCB
- * BOPA : ACPU
- * BOPU : uboot
- * BOPL : Linux
- * BOPZ : Zephyr
- */
-typedef struct rs_bop_header {
-	uint32_t bop_id;  // byte [3:1] 'B','O','P', byte[0] : binary type
-	uint16_t bop_hdr_version;
-	uint16_t sign_tool_version;
-	uint32_t binary_version;
-	uint32_t binary_len;
-	uint32_t load_addr;
-	uint32_t entry_addr;
-	uint32_t offset_to_binary;
-	uint32_t offset_to_next_header;
-	uint8_t sig_algo;
-	uint8_t option;
-	uint8_t enc_algo;
-	uint8_t iv_len;
-	uint16_t pub_key_len;
-	uint16_t enc_key_len;
-	uint16_t sig_len;
-	uint8_t compression_algo;
-	uint8_t bin_pad_bytes;  // Number of padding bytes in the payload binary or
-							// bitstream
-	uint16_t xcb_header_size;
-	uint8_t padding[16];  // To make BOP header 64 bytes for scatter gather hash
-						// calculation
-	uint16_t crc_16;
-} __attribute__((packed)) bop_header_t;
-
 typedef struct gemini_bit_file
 {
 	ubi_header_t *ubi_header;
-	bop_header_t **bop_header_list;
-	uint8_t *rawdata;
 	long filesize;
 } gemini_bit_file_t;
 
-int gemini_create_helper_bitstream(gemini_bit_file_t *bit_file, uint8_t **bitstream, uint32_t *filesize);
 int gemini_read_bit_file(gemini_bit_file_t *bit_file, const char *filename);
 void gemini_free_bit_file(gemini_bit_file_t *bit_file);
 


### PR DESCRIPTION
This PR include changes below : -
- Pick up latest ubi header struct with new fsbl_size field
- Remove CRC validation code 
- Simplify ubi file parsing and validity checking by using ubi_header_version and fsbl_size field
- Simplify helper bitstream handling by using fsbl_size field and assuming FSBL BOP is always the first BOP
- Remove excessive logging  