### PR TITLE
Create release only on push of tag

### DIFF
--- a/.github/workflows/LinuxBuild.yml
+++ b/.github/workflows/LinuxBuild.yml
@@ -1,7 +1,11 @@
 
 name: OpenOCD Linux Build
 
-on: [push, pull_request]
+on:
+   pull_request:
+   push:
+        tags:
+            '*' 
 
 jobs:
   build:
@@ -153,6 +157,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: ${{ env.ARTIFACT_PATH }}
+        
     # - name: Delete 'latest' Release
     #   if: "${{ github.ref == 'refs/heads/master' }}"
     #   uses: dev-drprasad/delete-tag-and-release@v0.2.1
@@ -161,10 +166,12 @@ jobs:
     #     tag_name: ${{ env.RELEASE_NAME }}
     #   env:
     #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create Release
-      if: "${{ github.ref == 'refs/heads/master' }}"
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       uses: ncipollo/release-action@v1
       with:
+        name: latest
         tag: ${{ env.RELEASE_NAME }}
         commit: ${{ github.sha }}
         draft: false

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,7 +2,11 @@
 
 # Copyright (C) 2020 by Tarek BOUCHKATI <tarek.bouchkati@gmail.com>
 
-on: push
+on:
+  pull_request:
+  push:
+       tags:
+           '*' 
 
 name: OpenOCD Snapshot
 
@@ -103,9 +107,10 @@ jobs:
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
-        if: "${{ github.ref == 'refs/heads/master' }}"
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1
         with:
+          name: latest  
           tag: ${{ env.RELEASE_NAME }}
           commit: ${{ github.sha }}
           draft: false


### PR DESCRIPTION
With this update,
CI will trigger only on PR or on pushing a new tag
the release will be updated/created only on pushing a new tag